### PR TITLE
Add `SELF_LOGS_PATH` env variable to allow setting different tool's log location & python 3.12 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Usually command line arguments will take the highest priority among the others. 
 
 ## Notes
 1. Currently only Cloudflare API Token can be used to authenticate against Cloudflare APIs. Global API key is not supported, as this is a more insecure option.
-2. All the logpull activity logs will be written in `/var/log/cf_logs_downloader/` folder. Make sure you have the appropriate permission (root) to run the script.
+2. All the logpull activity logs will be written in `/var/log/cf_logs_downloader/` folder (can be adjusted by `SELF_LOGS_PATH` env variable). Make sure you have the appropriate permission (root) to run the script.
 3. Each successful logpull activity will be written in `succ.log` file.
 4. If a logpull task failed, the failed task will be put inside a queue. A separate thread will keep checking the queue for new items, and reattempt the logpull process. The thread will pick up new items after each logpull activity for every 3 seconds. If there's 3 consequtive failed logpull activities, then the thread will wait for 60 seconds before performing the next logpull activity. 
 5. Some logpull tasks can't be retried because of known error (for example, requesting bot management field from a zone which does not have bot management enabled). In this case, the failed logpull activity will be written in `fail.log`.

--- a/cf_logs_downloader.py
+++ b/cf_logs_downloader.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+# Patch collections.Mapping usage in yschema
+# ref: https://stackoverflow.com/a/70557518
+import collections.abc
+collections.Mapping = collections.abc.Mapping
+
 #import libraries needed in this program
 #'requests' library needs to be installed first
 import requests, time, threading, os, json, logging, sys, argparse, logging.handlers, yaml, yschema, tempfile, signal, persistqueue

--- a/cf_logs_downloader.py
+++ b/cf_logs_downloader.py
@@ -62,10 +62,11 @@ succ_logger.setLevel(logging.INFO)
 fail_logger.setLevel(logging.INFO)
 
 #create handlers to write logs to local storage, and automatically rotate them
-Path("/var/log/cf_logs_downloader/").mkdir(parents=True, exist_ok=True)
-handler_file = logging.handlers.TimedRotatingFileHandler("/var/log/cf_logs_downloader/pull.log", when='H', interval=1, backupCount=120, utc=False, encoding="utf-8") #rotate hourly, store up to 120 hours
-succ_handler_file = logging.handlers.TimedRotatingFileHandler("/var/log/cf_logs_downloader/succ.log", when='D', interval=1, backupCount=30, utc=False, encoding="utf-8") #rotate daily, store up to 30 days
-fail_handler_file = logging.handlers.TimedRotatingFileHandler("/var/log/cf_logs_downloader/fail.log", when='D', interval=1, backupCount=30, utc=False, encoding="utf-8") #rotate daily, store up to 30 days
+self_logs_path = os.getenv("SELF_LOGS_PATH", "/var/log/cf_logs_downloader/")
+Path(self_logs_path).mkdir(parents=True, exist_ok=True)
+handler_file = logging.handlers.TimedRotatingFileHandler(f"{self_logs_path}pull.log", when='H', interval=1, backupCount=120, utc=False, encoding="utf-8") #rotate hourly, store up to 120 hours
+succ_handler_file = logging.handlers.TimedRotatingFileHandler(f"{self_logs_path}succ.log", when='D', interval=1, backupCount=30, utc=False, encoding="utf-8") #rotate daily, store up to 30 days
+fail_handler_file = logging.handlers.TimedRotatingFileHandler(f"{self_logs_path}fail.log", when='D', interval=1, backupCount=30, utc=False, encoding="utf-8") #rotate daily, store up to 30 days
 
 #create a handler to print logs on terminal
 handler_console = logging.StreamHandler()
@@ -86,7 +87,7 @@ succ_logger.addHandler(succ_handler_file)
 fail_logger.addHandler(fail_handler_file)
 
 #create a SQLite queue system to handle failed tasks
-queue = persistqueue.SQLiteQueue('/var/log/cf_logs_downloader/queue/', auto_commit=True, multithreading=True)
+queue = persistqueue.SQLiteQueue(f'{self_logs_path}queue/', auto_commit=True, multithreading=True)
 
 #create a threading event for wait() function
 event = threading.Event()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.25.1
-pyyaml==5.4.1
+pyyaml==6.0.1
 yschema==1.0.2
 persistqueue==0.1.6


### PR DESCRIPTION
Main reason for this change is that I'm trying to run this script in lambda as --one-time, and in that environment only `/tmp/*` is writable.

Also, I've updated pyyaml and introduced patching for `yschema` library to make it compatible with python 3.12.